### PR TITLE
이니, 태태 웹 브라우저 프로젝트 Step2

### DIFF
--- a/WebBrowser/WebBrowser/Base.lproj/Main.storyboard
+++ b/WebBrowser/WebBrowser/Base.lproj/Main.storyboard
@@ -47,7 +47,7 @@
                                 <items>
                                     <barButtonItem width="10" style="plain" systemItem="flexibleSpace" id="0gh-eB-YCD"/>
                                     <barButtonItem style="plain" id="KGF-c6-rzF">
-                                        <button key="customView" opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="vwG-ja-jsj">
+                                        <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="vwG-ja-jsj">
                                             <rect key="frame" x="92.5" y="16" width="13" height="22"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <state key="normal" image="chevron.backward" catalog="system"/>
@@ -69,7 +69,7 @@
                                     </barButtonItem>
                                     <barButtonItem style="plain" systemItem="flexibleSpace" id="Swx-WF-ft9"/>
                                     <barButtonItem style="plain" id="5Ll-kH-Zf3">
-                                        <button key="customView" opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="l2g-1E-r1i">
+                                        <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="l2g-1E-r1i">
                                             <rect key="frame" x="308.5" y="16" width="13" height="22"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <state key="normal" image="chevron.forward" catalog="system"/>
@@ -112,7 +112,7 @@
                         <outlet property="invalidURLLabel" destination="Tpy-ro-dPv" id="fHk-Ax-VvT"/>
                         <outlet property="moveToURLButton" destination="boo-Ca-gvx" id="DCu-Ig-GRt"/>
                         <outlet property="reloadPageButton" destination="l1S-E3-yOU" id="ip0-r1-FAP"/>
-                        <outlet property="serachURLBar" destination="0yF-GL-GVv" id="J1P-Ci-OOF"/>
+                        <outlet property="searchBarURL" destination="0yF-GL-GVv" id="J1P-Ci-OOF"/>
                         <outlet property="webView" destination="bJX-eM-fcZ" id="xE9-Lh-gsQ"/>
                     </connections>
                 </viewController>

--- a/WebBrowser/WebBrowser/Base.lproj/Main.storyboard
+++ b/WebBrowser/WebBrowser/Base.lproj/Main.storyboard
@@ -1,24 +1,46 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="WebBrowser" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <subviews>
+                            <wkWebView contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bJX-eM-fcZ">
+                                <rect key="frame" x="20" y="54" width="374" height="808"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <wkWebViewConfiguration key="configuration">
+                                    <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
+                                    <wkPreferences key="preferences"/>
+                                </wkWebViewConfiguration>
+                            </wkWebView>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
+                    <connections>
+                        <outlet property="webVeiw" destination="bJX-eM-fcZ" id="xE9-Lh-gsQ"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="-197.10144927536234" y="93.75"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/WebBrowser/WebBrowser/Base.lproj/Main.storyboard
+++ b/WebBrowser/WebBrowser/Base.lproj/Main.storyboard
@@ -16,21 +16,76 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-
-                            <wkWebView contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bJX-eM-fcZ">
-                                <rect key="frame" x="20" y="54" width="374" height="808"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bJX-eM-fcZ">
+                                <rect key="frame" x="0.0" y="44" width="414" height="769"/>
                                 <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <wkWebViewConfiguration key="configuration">
                                     <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
                                     <wkPreferences key="preferences"/>
                                 </wkWebViewConfiguration>
                             </wkWebView>
+                            <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LtC-MU-xBD">
+                                <rect key="frame" x="10" y="813" width="394" height="49"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <items>
+                                    <barButtonItem style="plain" systemItem="flexibleSpace" id="TEb-XH-0YC"/>
+                                    <barButtonItem title="back" style="plain" id="KX8-HM-wvI">
+                                        <inset key="landscapeImageInsets" minX="10" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                        <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="42Q-YP-odQ">
+                                            <rect key="frame" x="0.0" y="5" width="95" height="44"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                            <state key="normal" image="chevron.backward" catalog="system"/>
+                                            <connections>
+                                                <action selector="goBack" destination="BYZ-38-t0r" eventType="touchUpInside" id="5A6-Bz-Sai"/>
+                                            </connections>
+                                        </button>
+                                    </barButtonItem>
+                                    <barButtonItem width="42" style="plain" systemItem="fixedSpace" id="kQ5-wt-EH2"/>
+                                    <barButtonItem title="refresh" style="plain" id="8oU-Gy-icQ">
+                                        <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="La6-ml-5hU">
+                                            <rect key="frame" x="137" y="16" width="150" height="22"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                            <state key="normal" image="arrow.clockwise" catalog="system"/>
+                                            <connections>
+                                                <action selector="reloadPage" destination="BYZ-38-t0r" eventType="touchUpInside" id="vEw-5z-Juo"/>
+                                            </connections>
+                                        </button>
+                                    </barButtonItem>
+                                    <barButtonItem width="42" style="plain" systemItem="fixedSpace" id="EWb-gc-Ss8"/>
+                                    <barButtonItem title="forward" style="plain" id="qRr-3N-BR7">
+                                        <inset key="landscapeImageInsets" minX="0.0" minY="0.0" maxX="10" maxY="0.0"/>
+                                        <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="K3D-vg-swl">
+                                            <rect key="frame" x="299" y="5" width="95" height="44"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                            <state key="normal" image="chevron.forward" catalog="system"/>
+                                            <connections>
+                                                <action selector="goForward" destination="BYZ-38-t0r" eventType="touchUpInside" id="Etf-w5-6mJ"/>
+                                            </connections>
+                                        </button>
+                                    </barButtonItem>
+                                    <barButtonItem style="plain" systemItem="flexibleSpace" id="H24-uQ-zgy"/>
+                                </items>
+                                <color key="barTintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </toolbar>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="LtC-MU-xBD" firstAttribute="top" secondItem="bJX-eM-fcZ" secondAttribute="bottom" id="5R5-h7-EsH"/>
+                            <constraint firstItem="LtC-MU-xBD" firstAttribute="top" secondItem="bJX-eM-fcZ" secondAttribute="bottom" id="6j7-D6-cwd"/>
+                            <constraint firstItem="LtC-MU-xBD" firstAttribute="bottom" secondItem="6Tk-OE-BBY" secondAttribute="bottom" id="8eQ-0f-SV2"/>
+                            <constraint firstItem="LtC-MU-xBD" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="10" id="bt2-TG-lOG"/>
+                            <constraint firstItem="bJX-eM-fcZ" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="faT-YO-8bO"/>
+                            <constraint firstItem="bJX-eM-fcZ" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="l0i-SU-QjU"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="bJX-eM-fcZ" secondAttribute="trailing" id="mQE-kY-Lka"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="LtC-MU-xBD" secondAttribute="trailing" constant="10" id="vEr-kr-1L4"/>
+                        </constraints>
                     </view>
                     <connections>
+                        <outlet property="goBackButton" destination="KX8-HM-wvI" id="e0r-vw-4eB"/>
+                        <outlet property="goForwardButton" destination="qRr-3N-BR7" id="2MP-Ql-jkW"/>
+                        <outlet property="reloadPageButton" destination="8oU-Gy-icQ" id="idh-57-nHw"/>
                         <outlet property="webVeiw" destination="bJX-eM-fcZ" id="xE9-Lh-gsQ"/>
                     </connections>
                 </viewController>
@@ -40,6 +95,9 @@
         </scene>
     </scenes>
     <resources>
+        <image name="arrow.clockwise" catalog="system" width="115" height="128"/>
+        <image name="chevron.backward" catalog="system" width="96" height="128"/>
+        <image name="chevron.forward" catalog="system" width="96" height="128"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/WebBrowser/WebBrowser/Base.lproj/Main.storyboard
+++ b/WebBrowser/WebBrowser/Base.lproj/Main.storyboard
@@ -17,57 +17,13 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bJX-eM-fcZ">
-                                <rect key="frame" x="0.0" y="94" width="414" height="768"/>
+                                <rect key="frame" x="0.0" y="94" width="414" height="719"/>
                                 <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <wkWebViewConfiguration key="configuration">
                                     <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
                                     <wkPreferences key="preferences"/>
                                 </wkWebViewConfiguration>
                             </wkWebView>
-                            <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LtC-MU-xBD">
-                                <rect key="frame" x="10" y="813" width="394" height="49"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <items>
-                                    <barButtonItem style="plain" systemItem="flexibleSpace" id="TEb-XH-0YC"/>
-                                    <barButtonItem title="back" style="plain" id="KX8-HM-wvI">
-                                        <inset key="landscapeImageInsets" minX="10" minY="0.0" maxX="0.0" maxY="0.0"/>
-                                        <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="42Q-YP-odQ">
-                                            <rect key="frame" x="0.0" y="5" width="95" height="44"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="18"/>
-                                            <state key="normal" image="chevron.backward" catalog="system"/>
-                                            <connections>
-                                                <action selector="goBack" destination="BYZ-38-t0r" eventType="touchUpInside" id="5A6-Bz-Sai"/>
-                                            </connections>
-                                        </button>
-                                    </barButtonItem>
-                                    <barButtonItem width="42" style="plain" systemItem="fixedSpace" id="kQ5-wt-EH2"/>
-                                    <barButtonItem title="refresh" style="plain" id="8oU-Gy-icQ">
-                                        <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="La6-ml-5hU">
-                                            <rect key="frame" x="137" y="16" width="150" height="22"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                            <state key="normal" image="arrow.clockwise" catalog="system"/>
-                                            <connections>
-                                                <action selector="reloadPage" destination="BYZ-38-t0r" eventType="touchUpInside" id="vEw-5z-Juo"/>
-                                            </connections>
-                                        </button>
-                                    </barButtonItem>
-                                    <barButtonItem width="42" style="plain" systemItem="fixedSpace" id="EWb-gc-Ss8"/>
-                                    <barButtonItem title="forward" style="plain" id="qRr-3N-BR7">
-                                        <inset key="landscapeImageInsets" minX="0.0" minY="0.0" maxX="10" maxY="0.0"/>
-                                        <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="K3D-vg-swl">
-                                            <rect key="frame" x="299" y="5" width="95" height="44"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                            <state key="normal" image="chevron.forward" catalog="system"/>
-                                            <connections>
-                                                <action selector="goForward" destination="BYZ-38-t0r" eventType="touchUpInside" id="Etf-w5-6mJ"/>
-                                            </connections>
-                                        </button>
-                                    </barButtonItem>
-                                    <barButtonItem style="plain" systemItem="flexibleSpace" id="H24-uQ-zgy"/>
-                                </items>
-                                <color key="barTintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                            </toolbar>
                             <searchBar contentMode="redraw" translatesAutoresizingMaskIntoConstraints="NO" id="0yF-GL-GVv">
                                 <rect key="frame" x="20" y="44" width="334" height="50"/>
                                 <textInputTraits key="textInputTraits"/>
@@ -79,28 +35,83 @@
                                     <action selector="tappedMoveToURLButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="WwL-di-gdj"/>
                                 </connections>
                             </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="infoLabel" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Tpy-ro-dPv">
+                                <rect key="frame" x="0.0" y="437.5" width="414" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LtC-MU-xBD">
+                                <rect key="frame" x="0.0" y="813" width="414" height="49"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <items>
+                                    <barButtonItem width="10" style="plain" systemItem="flexibleSpace" id="0gh-eB-YCD"/>
+                                    <barButtonItem style="plain" id="KGF-c6-rzF">
+                                        <button key="customView" opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="vwG-ja-jsj">
+                                            <rect key="frame" x="92.5" y="16" width="13" height="22"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                            <state key="normal" image="chevron.backward" catalog="system"/>
+                                            <connections>
+                                                <action selector="goBack" destination="BYZ-38-t0r" eventType="touchUpInside" id="RMT-gN-vQ9"/>
+                                            </connections>
+                                        </button>
+                                    </barButtonItem>
+                                    <barButtonItem style="plain" systemItem="flexibleSpace" id="g1q-v4-P8o"/>
+                                    <barButtonItem style="plain" id="l1S-E3-yOU">
+                                        <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="rx8-bX-58j">
+                                            <rect key="frame" x="198" y="16" width="18" height="22"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                            <state key="normal" image="arrow.clockwise" catalog="system"/>
+                                            <connections>
+                                                <action selector="reloadPage" destination="BYZ-38-t0r" eventType="touchUpInside" id="tPr-06-VTj"/>
+                                            </connections>
+                                        </button>
+                                    </barButtonItem>
+                                    <barButtonItem style="plain" systemItem="flexibleSpace" id="Swx-WF-ft9"/>
+                                    <barButtonItem style="plain" id="5Ll-kH-Zf3">
+                                        <button key="customView" opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="l2g-1E-r1i">
+                                            <rect key="frame" x="308.5" y="16" width="13" height="22"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                            <state key="normal" image="chevron.forward" catalog="system"/>
+                                            <connections>
+                                                <action selector="goForward" destination="BYZ-38-t0r" eventType="touchUpInside" id="8GX-Gh-p4v"/>
+                                            </connections>
+                                        </button>
+                                    </barButtonItem>
+                                    <barButtonItem width="10" style="plain" systemItem="flexibleSpace" id="CTT-Yx-sjL"/>
+                                </items>
+                                <color key="barTintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </toolbar>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-			<constraints>
+                        <constraints>
                             <constraint firstItem="0yF-GL-GVv" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="5Qd-x5-nPX"/>
                             <constraint firstItem="boo-Ca-gvx" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="AvW-Rk-9Hh"/>
                             <constraint firstItem="0yF-GL-GVv" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="E3l-jE-i6B"/>
                             <constraint firstItem="boo-Ca-gvx" firstAttribute="leading" secondItem="0yF-GL-GVv" secondAttribute="trailing" constant="10" id="FjQ-AI-5RR"/>
+                            <constraint firstItem="Tpy-ro-dPv" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="KB1-O4-Tn8"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="Tpy-ro-dPv" secondAttribute="trailing" id="Kad-of-odi"/>
+                            <constraint firstItem="LtC-MU-xBD" firstAttribute="top" secondItem="bJX-eM-fcZ" secondAttribute="bottom" id="PLp-Si-Xw3"/>
+                            <constraint firstItem="Tpy-ro-dPv" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="T4u-Df-OMU"/>
                             <constraint firstItem="bJX-eM-fcZ" firstAttribute="top" secondItem="0yF-GL-GVv" secondAttribute="bottom" id="Twm-UU-lyH"/>
+                            <constraint firstItem="LtC-MU-xBD" firstAttribute="bottom" secondItem="6Tk-OE-BBY" secondAttribute="bottom" id="ZPb-aq-Fvh"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="boo-Ca-gvx" secondAttribute="trailing" constant="20" id="ZdC-RI-Kq5"/>
                             <constraint firstItem="bJX-eM-fcZ" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="50" id="bLE-K9-QrX"/>
+                            <constraint firstItem="LtC-MU-xBD" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="eEe-GB-GCl"/>
                             <constraint firstItem="bJX-eM-fcZ" firstAttribute="top" secondItem="boo-Ca-gvx" secondAttribute="bottom" id="jPU-oT-K8T"/>
+                            <constraint firstItem="LtC-MU-xBD" firstAttribute="top" secondItem="bJX-eM-fcZ" secondAttribute="bottom" id="kDH-Az-Ual"/>
                             <constraint firstItem="bJX-eM-fcZ" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="mQY-Zn-rwW"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="bJX-eM-fcZ" secondAttribute="trailing" id="nJg-ev-rs2"/>
-                            <constraint firstItem="bJX-eM-fcZ" firstAttribute="bottom" secondItem="6Tk-OE-BBY" secondAttribute="bottom" id="qd8-rc-9VC"/>
+                            <constraint firstItem="LtC-MU-xBD" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" id="oYS-Fm-Yon"/>
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="goBackButton" destination="KX8-HM-wvI" id="e0r-vw-4eB"/>
-                        <outlet property="goForwardButton" destination="qRr-3N-BR7" id="2MP-Ql-jkW"/>
-                        <outlet property="reloadPageButton" destination="8oU-Gy-icQ" id="idh-57-nHw"/>
+                        <outlet property="goBackButton" destination="KGF-c6-rzF" id="Onz-rF-E45"/>
+                        <outlet property="goForwardButton" destination="5Ll-kH-Zf3" id="Xm9-HP-CEL"/>
+                        <outlet property="invalidURLLabel" destination="Tpy-ro-dPv" id="fHk-Ax-VvT"/>
                         <outlet property="moveToURLButton" destination="boo-Ca-gvx" id="DCu-Ig-GRt"/>
+                        <outlet property="reloadPageButton" destination="l1S-E3-yOU" id="ip0-r1-FAP"/>
                         <outlet property="serachURLBar" destination="0yF-GL-GVv" id="J1P-Ci-OOF"/>
                         <outlet property="webView" destination="bJX-eM-fcZ" id="xE9-Lh-gsQ"/>
                     </connections>

--- a/WebBrowser/WebBrowser/Base.lproj/Main.storyboard
+++ b/WebBrowser/WebBrowser/Base.lproj/Main.storyboard
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -13,7 +12,7 @@
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="WebBrowser" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <wkWebView contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bJX-eM-fcZ">
@@ -30,7 +29,7 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                     <connections>
-                        <outlet property="webVeiw" destination="bJX-eM-fcZ" id="xE9-Lh-gsQ"/>
+                        <outlet property="webView" destination="bJX-eM-fcZ" id="xE9-Lh-gsQ"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/WebBrowser/WebBrowser/Base.lproj/Main.storyboard
+++ b/WebBrowser/WebBrowser/Base.lproj/Main.storyboard
@@ -82,13 +82,7 @@
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                    <connections>
-                        <outlet property="goBackButton" destination="KX8-HM-wvI" id="e0r-vw-4eB"/>
-                        <outlet property="goForwardButton" destination="qRr-3N-BR7" id="2MP-Ql-jkW"/>
-                        <outlet property="reloadPageButton" destination="8oU-Gy-icQ" id="idh-57-nHw"/>
-                        <outlet property="moveToURLButton" destination="boo-Ca-gvx" id="DCu-Ig-GRt"/>
-                        <outlet property="serachURLBar" destination="0yF-GL-GVv" id="J1P-Ci-OOF"/>
-                        <outlet property="webView" destination="bJX-eM-fcZ" id="xE9-Lh-gsQ"/>
+			<constraints>
                             <constraint firstItem="0yF-GL-GVv" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="5Qd-x5-nPX"/>
                             <constraint firstItem="boo-Ca-gvx" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="AvW-Rk-9Hh"/>
                             <constraint firstItem="0yF-GL-GVv" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="E3l-jE-i6B"/>
@@ -101,8 +95,15 @@
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="bJX-eM-fcZ" secondAttribute="trailing" id="nJg-ev-rs2"/>
                             <constraint firstItem="bJX-eM-fcZ" firstAttribute="bottom" secondItem="6Tk-OE-BBY" secondAttribute="bottom" id="qd8-rc-9VC"/>
                         </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="goBackButton" destination="KX8-HM-wvI" id="e0r-vw-4eB"/>
+                        <outlet property="goForwardButton" destination="qRr-3N-BR7" id="2MP-Ql-jkW"/>
+                        <outlet property="reloadPageButton" destination="8oU-Gy-icQ" id="idh-57-nHw"/>
+                        <outlet property="moveToURLButton" destination="boo-Ca-gvx" id="DCu-Ig-GRt"/>
+                        <outlet property="serachURLBar" destination="0yF-GL-GVv" id="J1P-Ci-OOF"/>
+                        <outlet property="webView" destination="bJX-eM-fcZ" id="xE9-Lh-gsQ"/>
                     </connections>
-                   </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/WebBrowser/WebBrowser/Base.lproj/Main.storyboard
+++ b/WebBrowser/WebBrowser/Base.lproj/Main.storyboard
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -12,12 +13,11 @@
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="WebBrowser" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <wkWebView contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bJX-eM-fcZ">
-                                <rect key="frame" x="20" y="54" width="374" height="808"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bJX-eM-fcZ">
+                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                                 <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <wkWebViewConfiguration key="configuration">
                                     <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
@@ -27,6 +27,12 @@
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="bJX-eM-fcZ" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="bLE-K9-QrX"/>
+                            <constraint firstItem="bJX-eM-fcZ" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="mQY-Zn-rwW"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="bJX-eM-fcZ" secondAttribute="trailing" id="nJg-ev-rs2"/>
+                            <constraint firstItem="bJX-eM-fcZ" firstAttribute="bottom" secondItem="6Tk-OE-BBY" secondAttribute="bottom" id="qd8-rc-9VC"/>
+                        </constraints>
                     </view>
                     <connections>
                         <outlet property="webView" destination="bJX-eM-fcZ" id="xE9-Lh-gsQ"/>

--- a/WebBrowser/WebBrowser/Base.lproj/Main.storyboard
+++ b/WebBrowser/WebBrowser/Base.lproj/Main.storyboard
@@ -82,7 +82,6 @@
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                    </view>
                     <connections>
                         <outlet property="goBackButton" destination="KX8-HM-wvI" id="e0r-vw-4eB"/>
                         <outlet property="goForwardButton" destination="qRr-3N-BR7" id="2MP-Ql-jkW"/>
@@ -103,6 +102,7 @@
                             <constraint firstItem="bJX-eM-fcZ" firstAttribute="bottom" secondItem="6Tk-OE-BBY" secondAttribute="bottom" id="qd8-rc-9VC"/>
                         </constraints>
                     </connections>
+                   </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/WebBrowser/WebBrowser/Base.lproj/Main.storyboard
+++ b/WebBrowser/WebBrowser/Base.lproj/Main.storyboard
@@ -1,24 +1,60 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="WebBrowser" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <subviews>
+                            <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2lh-yW-b2c">
+                                <rect key="frame" x="0.0" y="94" width="414" height="768"/>
+                                <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <wkWebViewConfiguration key="configuration">
+                                    <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
+                                    <wkPreferences key="preferences"/>
+                                </wkWebViewConfiguration>
+                            </wkWebView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Info Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lCY-NV-AQd">
+                                <rect key="frame" x="169.5" y="437.5" width="75" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="lCY-NV-AQd" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="14l-ob-b8I"/>
+                            <constraint firstItem="2lh-yW-b2c" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="50J-5s-Dbc"/>
+                            <constraint firstItem="2lh-yW-b2c" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="50" id="Amq-1Z-EfA"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="2lh-yW-b2c" secondAttribute="bottom" id="NrH-XV-TFy"/>
+                            <constraint firstItem="lCY-NV-AQd" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="Xjh-By-R66"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="2lh-yW-b2c" secondAttribute="trailing" id="yQr-YV-cHJ"/>
+                        </constraints>
                     </view>
+                    <connections>
+                        <outlet property="infoLabel" destination="lCY-NV-AQd" id="SQg-au-Vk1"/>
+                        <outlet property="webView" destination="2lh-yW-b2c" id="T92-rk-Apb"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="12" y="28"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/WebBrowser/WebBrowser/Base.lproj/Main.storyboard
+++ b/WebBrowser/WebBrowser/Base.lproj/Main.storyboard
@@ -17,24 +17,44 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bJX-eM-fcZ">
-                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <rect key="frame" x="0.0" y="94" width="414" height="768"/>
                                 <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <wkWebViewConfiguration key="configuration">
                                     <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
                                     <wkPreferences key="preferences"/>
                                 </wkWebViewConfiguration>
                             </wkWebView>
+                            <searchBar contentMode="redraw" translatesAutoresizingMaskIntoConstraints="NO" id="0yF-GL-GVv">
+                                <rect key="frame" x="20" y="44" width="334" height="50"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </searchBar>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="boo-Ca-gvx">
+                                <rect key="frame" x="364" y="44" width="30" height="50"/>
+                                <state key="normal" title="이동"/>
+                                <connections>
+                                    <action selector="tappedMoveToURLButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="WwL-di-gdj"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="bJX-eM-fcZ" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="bLE-K9-QrX"/>
+                            <constraint firstItem="0yF-GL-GVv" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="5Qd-x5-nPX"/>
+                            <constraint firstItem="boo-Ca-gvx" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="AvW-Rk-9Hh"/>
+                            <constraint firstItem="0yF-GL-GVv" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="E3l-jE-i6B"/>
+                            <constraint firstItem="boo-Ca-gvx" firstAttribute="leading" secondItem="0yF-GL-GVv" secondAttribute="trailing" constant="10" id="FjQ-AI-5RR"/>
+                            <constraint firstItem="bJX-eM-fcZ" firstAttribute="top" secondItem="0yF-GL-GVv" secondAttribute="bottom" id="Twm-UU-lyH"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="boo-Ca-gvx" secondAttribute="trailing" constant="20" id="ZdC-RI-Kq5"/>
+                            <constraint firstItem="bJX-eM-fcZ" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="50" id="bLE-K9-QrX"/>
+                            <constraint firstItem="bJX-eM-fcZ" firstAttribute="top" secondItem="boo-Ca-gvx" secondAttribute="bottom" id="jPU-oT-K8T"/>
                             <constraint firstItem="bJX-eM-fcZ" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="mQY-Zn-rwW"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="bJX-eM-fcZ" secondAttribute="trailing" id="nJg-ev-rs2"/>
                             <constraint firstItem="bJX-eM-fcZ" firstAttribute="bottom" secondItem="6Tk-OE-BBY" secondAttribute="bottom" id="qd8-rc-9VC"/>
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="moveToURLButton" destination="boo-Ca-gvx" id="DCu-Ig-GRt"/>
+                        <outlet property="serachURLBar" destination="0yF-GL-GVv" id="J1P-Ci-OOF"/>
                         <outlet property="webView" destination="bJX-eM-fcZ" id="xE9-Lh-gsQ"/>
                     </connections>
                 </viewController>

--- a/WebBrowser/WebBrowser/Info.plist
+++ b/WebBrowser/WebBrowser/Info.plist
@@ -62,5 +62,9 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+    <key>NSAppTransportSecurity</key>
+        <dict>
+            <key>NSAllowsArbitraryLoads</key><true/>
+        </dict>
 </dict>
 </plist>

--- a/WebBrowser/WebBrowser/ViewController.swift
+++ b/WebBrowser/WebBrowser/ViewController.swift
@@ -5,14 +5,21 @@
 // 
 
 import UIKit
+import WebKit
 
 class ViewController: UIViewController {
-
+    
+    @IBOutlet weak var webVeiw: WKWebView!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
+        
+        guard let initialURL = URL(string: "https://m.naver.com") else {
+                    print("URL is nil : 잘못된 값이 입력되었습니다.")
+                    return
     }
+        let urlRequest = URLRequest(url: initialURL)
+        webVeiw.load(urlRequest)
 
-
+    }
 }
-

--- a/WebBrowser/WebBrowser/ViewController.swift
+++ b/WebBrowser/WebBrowser/ViewController.swift
@@ -15,18 +15,27 @@ class ViewController: UIViewController {
     @IBOutlet weak var reloadPageButton: UIBarButtonItem!
     @IBOutlet weak var serachURLBar: UISearchBar!
     @IBOutlet weak var moveToURLButton: UIButton!
+    @IBOutlet weak var invalidURLLabel: UILabel!
     
     override func viewDidLoad() {
         
         super.viewDidLoad()
-    
-        guard let initialURL = URL(string: "https://m.naver.com") else {
-                    print("URL is nil : 잘못된 값이 입력되었습니다.")
-                    return
+        invalidURLLabel.isHidden = true
+        
+        guard let initialURL = URL(string: "https://m.naver.com ") else {
+            print("URL is nil : 잘못된 값이 입력되었습니다.")
+            invalidURLLabel.text = "잘못된 URL값 입니다."
+            invalidURLLabel.isHidden = false
+            return
         }
         
-        loadURL(of: initialURL)
-
+        loadWebView(of: initialURL)
+        
+        goBackButton.isEnabled = webView.canGoBack
+        goForwardButton.isEnabled = webView.canGoForward
+        
+        webView.addObserver(self, forKeyPath: "loading", options: .new, context: nil)
+        
     }
     
     @IBAction func goBack() {
@@ -44,27 +53,33 @@ class ViewController: UIViewController {
     }
     
     @IBAction func reloadPage() {
-        
         webView.reload()
     }
-        
+    
     @IBAction func tappedMoveToURLButton(_ sender: UIButton) {
         
         guard let requestedURLText = serachURLBar.text else {
             return
         }
         
-        guard let requestedURL = URL(string: "https://"+requestedURLText) else{
+        guard let requestedURL = URL(string: "https://"+requestedURLText) else {
             return
         }
         
-        loadURL(of: requestedURL)
+        loadWebView(of: requestedURL)
+    }
+    
+    override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+        if (keyPath == "loading") {
+            goBackButton.isEnabled = webView.canGoBack
+            goForwardButton.isEnabled = webView.canGoForward
+        }
     }
 }
 
 extension ViewController {
     
-    private func loadURL(of requestedURL: URL){
+    private func loadWebView(of requestedURL: URL) {
         let urlRequest = URLRequest(url: requestedURL)
         serachURLBar.text = requestedURL.absoluteString
         webView.load(urlRequest)

--- a/WebBrowser/WebBrowser/ViewController.swift
+++ b/WebBrowser/WebBrowser/ViewController.swift
@@ -9,7 +9,7 @@ import WebKit
 
 class ViewController: UIViewController {
     
-    @IBOutlet weak var webVeiw: WKWebView!
+    @IBOutlet weak var webView: WKWebView!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -19,7 +19,7 @@ class ViewController: UIViewController {
                     return
     }
         let urlRequest = URLRequest(url: initialURL)
-        webVeiw.load(urlRequest)
+        webView.load(urlRequest)
 
     }
 }

--- a/WebBrowser/WebBrowser/ViewController.swift
+++ b/WebBrowser/WebBrowser/ViewController.swift
@@ -58,6 +58,7 @@ class ViewController: UIViewController {
     
     @IBAction func tappedMoveToURLButton(_ sender: UIButton) {
         guard let requestedURL = convertToURL(of: searchBarURL.text) else {
+            print("URL is nil : 잘못된 값이 입력되었습니다.")
             return
         }
         loadWebView(of: requestedURL)
@@ -74,11 +75,10 @@ class ViewController: UIViewController {
 
 extension ViewController {
     
-    private func loadWebView(of requestedURL: URL){
+    private func loadWebView(of requestedURL: URL) {
         let urlRequest = URLRequest(url: requestedURL)
         searchBarURL.text = requestedURL.absoluteString
         webView.load(urlRequest)
-        
     }
     
     private func convertToURL(of searchBarText: String?) -> URL? {

--- a/WebBrowser/WebBrowser/ViewController.swift
+++ b/WebBrowser/WebBrowser/ViewController.swift
@@ -10,16 +10,40 @@ import WebKit
 class ViewController: UIViewController {
     
     @IBOutlet weak var webVeiw: WKWebView!
+    @IBOutlet weak var goBackButton: UIBarButtonItem!
+    @IBOutlet weak var goForwardButton: UIBarButtonItem!
+    @IBOutlet weak var reloadPageButton: UIBarButtonItem!
     
     override func viewDidLoad() {
+        
         super.viewDidLoad()
         
         guard let initialURL = URL(string: "https://m.naver.com") else {
                     print("URL is nil : 잘못된 값이 입력되었습니다.")
                     return
-    }
+        }
+        
         let urlRequest = URLRequest(url: initialURL)
         webVeiw.load(urlRequest)
 
+    }
+    
+    @IBAction func goBack() {
+        
+        if webVeiw.canGoBack {
+            webVeiw.goBack()
+        }
+    }
+    
+    @IBAction func goForward() {
+        
+        if webVeiw.canGoForward {
+            webVeiw.goForward()
+        }
+    }
+    
+    @IBAction func reloadPage() {
+        
+        webVeiw.reload()
     }
 }

--- a/WebBrowser/WebBrowser/ViewController.swift
+++ b/WebBrowser/WebBrowser/ViewController.swift
@@ -9,7 +9,7 @@ import WebKit
 
 class ViewController: UIViewController {
     
-    @IBOutlet weak var webVeiw: WKWebView!
+    @IBOutlet weak var webView: WKWebView!
     @IBOutlet weak var goBackButton: UIBarButtonItem!
     @IBOutlet weak var goForwardButton: UIBarButtonItem!
     @IBOutlet weak var reloadPageButton: UIBarButtonItem!
@@ -31,21 +31,21 @@ class ViewController: UIViewController {
     
     @IBAction func goBack() {
         
-        if webVeiw.canGoBack {
-            webVeiw.goBack()
+        if webView.canGoBack {
+            webView.goBack()
         }
     }
     
     @IBAction func goForward() {
         
-        if webVeiw.canGoForward {
-            webVeiw.goForward()
+        if webView.canGoForward {
+            webView.goForward()
         }
     }
     
     @IBAction func reloadPage() {
         
-        webVeiw.reload()
+        webView.reload()
     }
         
     @IBAction func tappedMoveToURLButton(_ sender: UIButton) {

--- a/WebBrowser/WebBrowser/ViewController.swift
+++ b/WebBrowser/WebBrowser/ViewController.swift
@@ -5,14 +5,22 @@
 // 
 
 import UIKit
-
+import WebKit
 class ViewController: UIViewController {
-
+    @IBOutlet weak var webView: WKWebView!
+    @IBOutlet weak var infoLabel: UILabel!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
+        infoLabel.isHidden = true
+        
+        guard let bookmarkURL = URL(string:"https://m.nate.com") else {
+            infoLabel.isHidden = false
+            infoLabel.text = "해당 주소URL을 찾을 수 없습니다."
+            return
+        }
+       
+        let urlRequest = URLRequest(url: bookmarkURL)
+        webView.load(urlRequest)
     }
-
-
 }
-

--- a/WebBrowser/WebBrowser/ViewController.swift
+++ b/WebBrowser/WebBrowser/ViewController.swift
@@ -10,16 +10,39 @@ import WebKit
 class ViewController: UIViewController {
     
     @IBOutlet weak var webView: WKWebView!
+    @IBOutlet weak var serachURLBar: UISearchBar!
+    @IBOutlet weak var moveToURLButton: UIButton!
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+    
         guard let initialURL = URL(string: "https://m.naver.com") else {
-                    print("URL is nil : 잘못된 값이 입력되었습니다.")
-                    return
+            print("URL is nil : 잘못된 값이 입력되었습니다.")
+            return
+        }
+        
+        loadURL(of: initialURL)
     }
-        let urlRequest = URLRequest(url: initialURL)
+    
+    @IBAction func tappedMoveToURLButton(_ sender: UIButton) {
+        
+        guard let requestedURLText = serachURLBar.text else {
+            return
+        }
+        
+        guard let requestedURL = URL(string: "https://"+requestedURLText) else{
+            return
+        }
+        
+        loadURL(of: requestedURL)
+    }
+}
+extension ViewController {
+    
+    private func loadURL(of requestedURL: URL){
+        let urlRequest = URLRequest(url: requestedURL)
+        serachURLBar.text = requestedURL.absoluteString
         webView.load(urlRequest)
-
     }
+    
 }

--- a/WebBrowser/WebBrowser/ViewController.swift
+++ b/WebBrowser/WebBrowser/ViewController.swift
@@ -67,14 +67,18 @@ class ViewController: UIViewController {
         if (keyPath == "loading") {
             goBackButton.isEnabled = webView.canGoBack
             goForwardButton.isEnabled = webView.canGoForward
+            showCurrentAddress()
         }
     }
 }
+
 extension ViewController {
+    
     private func loadWebView(of requestedURL: URL){
         let urlRequest = URLRequest(url: requestedURL)
         searchBarURL.text = requestedURL.absoluteString
         webView.load(urlRequest)
+        
     }
     
     private func convertToURL(of searchBarText: String?) -> URL? {
@@ -82,7 +86,7 @@ extension ViewController {
             return nil
         }
         
-        if requestedURLText.hasPrefix("https://") {
+        if requestedURLText.hasPrefix("https://") || requestedURLText.hasPrefix("http://") {
             return URL(string: requestedURLText)
         }else{
             return URL(string:"https://" + requestedURLText)
@@ -90,4 +94,8 @@ extension ViewController {
         }
     }
     
+    private func showCurrentAddress() {
+        let currentAddress = webView.url
+        searchBarURL.text = currentAddress?.absoluteString
+    }
 }

--- a/WebBrowser/WebBrowser/ViewController.swift
+++ b/WebBrowser/WebBrowser/ViewController.swift
@@ -13,7 +13,7 @@ class ViewController: UIViewController {
     @IBOutlet weak var goBackButton: UIBarButtonItem!
     @IBOutlet weak var goForwardButton: UIBarButtonItem!
     @IBOutlet weak var reloadPageButton: UIBarButtonItem!
-    @IBOutlet weak var serachURLBar: UISearchBar!
+    @IBOutlet weak var searchBarURL: UISearchBar!
     @IBOutlet weak var moveToURLButton: UIButton!
     @IBOutlet weak var invalidURLLabel: UILabel!
     
@@ -22,7 +22,7 @@ class ViewController: UIViewController {
         super.viewDidLoad()
         invalidURLLabel.isHidden = true
         
-        guard let initialURL = URL(string: "https://m.naver.com ") else {
+        guard let initialURL = URL(string: "https://m.naver.com") else {
             print("URL is nil : 잘못된 값이 입력되었습니다.")
             invalidURLLabel.text = "잘못된 URL값 입니다."
             invalidURLLabel.isHidden = false
@@ -57,15 +57,9 @@ class ViewController: UIViewController {
     }
     
     @IBAction func tappedMoveToURLButton(_ sender: UIButton) {
-        
-        guard let requestedURLText = serachURLBar.text else {
+        guard let requestedURL = convertToURL(of: searchBarURL.text) else {
             return
         }
-        
-        guard let requestedURL = URL(string: "https://"+requestedURLText) else {
-            return
-        }
-        
         loadWebView(of: requestedURL)
     }
     
@@ -76,13 +70,24 @@ class ViewController: UIViewController {
         }
     }
 }
-
 extension ViewController {
-    
-    private func loadWebView(of requestedURL: URL) {
+    private func loadWebView(of requestedURL: URL){
         let urlRequest = URLRequest(url: requestedURL)
-        serachURLBar.text = requestedURL.absoluteString
+        searchBarURL.text = requestedURL.absoluteString
         webView.load(urlRequest)
+    }
+    
+    private func convertToURL(of searchBarText: String?) -> URL? {
+        guard let requestedURLText = searchBarText else {
+            return nil
+        }
+        
+        if requestedURLText.hasPrefix("https://") {
+            return URL(string: requestedURLText)
+        }else{
+            return URL(string:"https://" + requestedURLText)
+            
+        }
     }
     
 }

--- a/WebBrowser/WebBrowser/ViewController.swift
+++ b/WebBrowser/WebBrowser/ViewController.swift
@@ -18,8 +18,8 @@ class ViewController: UIViewController {
     @IBOutlet weak var invalidURLLabel: UILabel!
     
     override func viewDidLoad() {
-        
         super.viewDidLoad()
+        searchBarURL.delegate = self
         invalidURLLabel.isHidden = true
         
         guard let initialURL = URL(string: "https://m.naver.com") else {
@@ -39,14 +39,12 @@ class ViewController: UIViewController {
     }
     
     @IBAction func goBack() {
-        
         if webView.canGoBack {
             webView.goBack()
         }
     }
     
     @IBAction func goForward() {
-        
         if webView.canGoForward {
             webView.goForward()
         }
@@ -72,9 +70,18 @@ class ViewController: UIViewController {
         }
     }
 }
+extension ViewController: UISearchBarDelegate {
+    private func searchBarTextDidBeginEditing(_ searchBar: UISearchBar) -> Bool {
+        searchBar.becomeFirstResponder()
+    }
+    
+    func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+        tappedMoveToURLButton(moveToURLButton)
+        searchBar.resignFirstResponder()
+    }
+}
 
 extension ViewController {
-    
     private func loadWebView(of requestedURL: URL) {
         let urlRequest = URLRequest(url: requestedURL)
         searchBarURL.text = requestedURL.absoluteString


### PR DESCRIPTION
전체적으로 코드의 구조화에 신경을 썼으며, 이를 위해서 중복된 코드를 하나의 함수로 만들고자 했습니다. 
IBAction함수, override함수와 직접 구현한 함수를 구분지어서 직접 구현한 함수는 extension으로 빼서 가독성을 높이고자 했습니다.

Git merge 하면서 처음으로 storyboard에서 발생한 conflict 해결해보았습니다. 코드만 보다가 태그로 이루어진 것을 보아서 자세하게 어떤걸 의미하는지 확인하는 과정이 힘들었습니다. 해결해서 너무 기분이 좋았습니다 !! 

다음 Step에서는 필수적인 스토리보드 구성을 하고 각자 작업을 하고, 수정사항이 생기더라도 최소한으로 conflict를 줄여야겠다고 판단하였습니다.

1. 이전 step에서 들여쓰기 내용 수정하였습니다.

2. SearchBar ,ToolBar 각각 화면 상,하단에 배치하였고 Autolayout 설정했습니다.
 2-1) tool bar 각 버튼 사이의 간격을 균등하게 주기 위해 flexible space를 배치하였습니다.
 2-2) 뒤로 가기, 앞으로 가기 버튼에 활성화, 비활성화 효과를 주었습니다. 
 2-3) search bar 좌우 양 끝에 여백을 주어서 누르기 편하게 했습니다.

3. viewDidLoad()
 - initialURL로 첫 웹페이지를 설정 , 해당 URL 옵셔널 언래핑에 실패하면 잘못된 URL 값이라는 Text 문구를 Label로 나타나게 표현했습니다.
 - 이후에 loadWebView(of : URL 주소) 를 호출하여 webView를 로딩하는 함수를 구현했습니다.
 - webView에 addObserver 로 Keypath가 loading 인 경우를 설정하여 ToolBar에 앞,뒤로가기 버튼 비/활성화 기능을 구현했습니다.

4. goBack, goForward, reloadPage
 - WKWebView에 있는 메서드를 사용하여 구현했습니다.

5. tappedMoveToURLButton() 
 - 이동 버튼 클릭 시 실행되는 함수입니다.
 - searchbar 에 있는 Text 내용을 convertToURL()를 이용해서 URL로 변환하고 loadWebView()를 통해서 해당 URL에 맞는 페이지를 로드해줍니다.

6. observeValue() 
- viewDidLoad() 에서 webView.addObserver에 대응하는 함수로 Keypath가 loading인 경우 ToolBar의 버튼들이 동작이 활성화 되고 showCurrentAddress() 호출을 통해 SearchBar의 Text가 현재 URL 주소를 보여주게 됩니다.

7. loadWebView()
 - 파라미터로 URL 값을 받아서 urlRequest로 변환해주고 webView.load() 를 통해 알맞은 화면을 로드해 줍니다. 

8. convertToURL() 
- SearchBar의 Text 값을 String으로 받아 URL로 변환 시켜 줍니다.

9 . showCurrentAddress()
- webView.url 메서드로 현재 페이지의 URL주소를 가져와 SearchBar의 Text 값을 업데이트 시켜줍니다. 