### PR TITLE
feat: Step3 - URL 유효성 검증 및 알림창 구현

### DIFF
--- a/WebBrowser/WebBrowser/Base.lproj/Main.storyboard
+++ b/WebBrowser/WebBrowser/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>

--- a/WebBrowser/WebBrowser/ViewController.swift
+++ b/WebBrowser/WebBrowser/ViewController.swift
@@ -16,18 +16,29 @@ class ViewController: UIViewController {
     
     //MARK:- IBActions
     @IBAction func moveToURL(_ sender: UIButton) {
-        guard let inputURLString = textFieldForURL.text, let url = URL(string: inputURLString) else { return }
-        if let validURL = textFieldForURL.text, validURL.hasPrefix("http://") || validURL.hasPrefix("https://") {
+        guard let inputURLString = textFieldForURL.text, let url = URL(string: inputURLString) else {
+            let inputURLAlert = UIAlertController(title: "경고", message: "주소창에 이동하고자 하는 페이지의 주소를 입력해주세요.", preferredStyle: .alert)
+            inputURLAlert.addAction(UIAlertAction(title: "확인", style: .default, handler: { _ in
+                self.textFieldForURL.becomeFirstResponder()
+            }))
+            self.present(inputURLAlert, animated: true, completion: nil)
+            return
+        }
+        
+        let range = NSRange(location: 0, length: inputURLString.count)
+        let regExpForValidURL = try! NSRegularExpression(pattern: "http(s)?://")
+        
+        if regExpForValidURL.firstMatch(in: inputURLString, range: range) != nil {
             let request = URLRequest(url: url)
             textFieldForURL.text?.removeAll()
             textFieldForURL.endEditing(true)
             webView.load(request)
         } else {
-            let alertIndicatingInvalidURL = UIAlertController(title: "경고", message: "입력한 주소가 올바른 형태가 아닙니다. http:// 또는 https:// 를 넣은 URL로 입력해주세요.", preferredStyle: .alert)
-            alertIndicatingInvalidURL.addAction(UIAlertAction(title: "확인", style: .default, handler: { _ in
+            let invalidURLAlert = UIAlertController(title: "경고", message: "입력한 주소가 올바른 형태가 아닙니다. http://www 또는 https://www 를 넣은 URL로 입력해주세요.", preferredStyle: .alert)
+            invalidURLAlert.addAction(UIAlertAction(title: "확인", style: .default, handler: { _ in
                 self.textFieldForURL.becomeFirstResponder()
             }))
-            self.present(alertIndicatingInvalidURL, animated: true, completion: nil)
+            self.present(invalidURLAlert, animated: true, completion: nil)
         }
     }
     
@@ -50,6 +61,8 @@ class ViewController: UIViewController {
         textFieldForURL.returnKeyType = UIReturnKeyType.go
         textFieldForURL.clearButtonMode = UITextField.ViewMode.whileEditing
         
+        self.webView.navigationDelegate = self
+        
         guard let url = URL(string: "https://yagom.net") else { return }
         let request = URLRequest(url: url)
         webView.load(request)
@@ -61,5 +74,15 @@ extension ViewController: UITextFieldDelegate {
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         self.moveToURL(moveToURLButton)
         return true
+    }
+}
+
+extension ViewController: WKNavigationDelegate {
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        let pageNotFoundAlert = UIAlertController(title: "경고", message: "요청하신 페이지를 찾을 수 없습니다.", preferredStyle: .alert)
+        pageNotFoundAlert.addAction(UIAlertAction(title: "확인", style: .default, handler: { _ in
+            self.textFieldForURL.becomeFirstResponder()
+        }))
+        self.present(pageNotFoundAlert, animated: true, completion: nil)
     }
 }

--- a/WebBrowser/WebBrowser/ViewController.swift
+++ b/WebBrowser/WebBrowser/ViewController.swift
@@ -17,11 +17,20 @@ class ViewController: UIViewController {
     //MARK:- IBActions
     @IBAction func moveToURL(_ sender: UIButton) {
         guard let inputURLString = textFieldForURL.text, let url = URL(string: inputURLString) else { return }
-        let request = URLRequest(url: url)
-        textFieldForURL.text?.removeAll()
-        textFieldForURL.endEditing(true)
-        webView.load(request)
+        if let validURL = textFieldForURL.text, validURL.hasPrefix("http://") || validURL.hasPrefix("https://") {
+            let request = URLRequest(url: url)
+            textFieldForURL.text?.removeAll()
+            textFieldForURL.endEditing(true)
+            webView.load(request)
+        } else {
+            let alertIndicatingInvalidURL = UIAlertController(title: "경고", message: "입력한 주소가 올바른 형태가 아닙니다. http:// 또는 https:// 를 넣은 URL로 입력해주세요.", preferredStyle: .alert)
+            alertIndicatingInvalidURL.addAction(UIAlertAction(title: "확인", style: .default, handler: { _ in
+                self.textFieldForURL.becomeFirstResponder()
+            }))
+            self.present(alertIndicatingInvalidURL, animated: true, completion: nil)
+        }
     }
+    
     @IBAction func moveBackwards(_ sender: Any) {
         webView.goBack()
     }
@@ -39,6 +48,7 @@ class ViewController: UIViewController {
         textFieldForURL.keyboardType = UIKeyboardType.URL
         textFieldForURL.autocorrectionType = UITextAutocorrectionType.no
         textFieldForURL.returnKeyType = UIReturnKeyType.go
+        textFieldForURL.clearButtonMode = UITextField.ViewMode.whileEditing
         
         guard let url = URL(string: "https://yagom.net") else { return }
         let request = URLRequest(url: url)
@@ -46,6 +56,7 @@ class ViewController: UIViewController {
     }
 }
 
+//MARK:- Extensions
 extension ViewController: UITextFieldDelegate {
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         self.moveToURL(moveToURLButton)


### PR DESCRIPTION
* 유효한 주소일 때는 페이지가 로드되도록, 유효하지 않은 주소일 때는 알림창으로 경고를 준 다음, 입력창으로 포커스가 이동하도록 했습니다.
* 입력창의 삭제 편의성을 위해 clear 버튼을 편집하는 동안 사용할 수 있도록 추가했습니다.